### PR TITLE
Release 0.8.5

### DIFF
--- a/packages/react-scripts/.eslintrc
+++ b/packages/react-scripts/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "react-app"
+  "extends": "sharetribe"
 }

--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -17,3 +17,4 @@ In this fork, we have the following changes:
    - [postcss-import](https://github.com/postcss/postcss-import) for inlining `@import` rules in CSS files
 - Build as an UMD module to import the bundle for server side rendering
 - Rename package as `sharetribe-scripts` to be able to publish it to NPM
+- Use [eslint-config-sharetribe](https://www.npmjs.com/package/eslint-config-sharetribe) ESLint configuration instead of the default `eslint-config-react-app`.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharetribe-scripts",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Opinionated react-scripts fork with a CSS setup and a UMD output for server side.",
   "repository": "sharetribe/create-react-app",
   "license": "BSD-3-Clause",
@@ -36,13 +36,15 @@
     "css-loader": "0.26.0",
     "detect-port": "1.0.1",
     "dotenv": "2.0.0",
-    "eslint": "3.8.1",
-    "eslint-config-react-app": "^0.5.0",
+
+    "eslint-config-sharetribe": "0.1.0",
+    "eslint": "^3.13.0",
+    "eslint-plugin-jsx-a11y": "^3.0.2",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-react": "^6.9.0",
+
     "eslint-loader": "1.6.0",
-    "eslint-plugin-flowtype": "2.21.0",
-    "eslint-plugin-import": "2.0.1",
-    "eslint-plugin-jsx-a11y": "2.2.3",
-    "eslint-plugin-react": "6.4.1",
+
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.9.0",
     "filesize": "3.3.0",


### PR DESCRIPTION
This PR changes the `sharetribe-scripts` package to use the [eslint-config-sharetribe](https://github.com/sharetribe/eslint-config-sharetribe) ESLint configuration.