### PR TITLE
Reorganise fork 2

### DIFF
--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -1,7 +1,76 @@
-# react-scripts
+# sharetribe-scripts
 
-This package includes scripts and configuration used by [Create React App](https://github.com/facebookincubator/create-react-app).<br>
-Please refer to its documentation:
+This is a fork of the
+[react-scripts](https://github.com/facebookincubator/create-react-app/tree/master/packages/react-scripts)
+package from the
+[facebookincubator/create-react-app](https://github.com/facebookincubator/create-react-app)
+monorepo.
 
-* [Getting Started](https://github.com/facebookincubator/create-react-app/blob/master/README.md#getting-started) – How to create a new app.
-* [User Guide](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md) – How to develop apps bootstrapped with Create React App.
+This package is published as
+[sharetribe-scripts](https://www.npmjs.com/package/sharetribe-scripts)
+in NPM.
+
+See the `description` field in [package.json](package.json) to see
+which version of `react-scripts` this fork is built from.
+
+## Differences to `react-scripts`
+
+ - Use [CSS Modules](https://github.com/css-modules/css-modules)
+ - Use [cssnext](http://cssnext.io/)
+ - Use [postcss-import](https://github.com/postcss/postcss-import)
+ - Build an UMD module in production mode to support server side rendering
+
+## Development
+
+### Setup
+
+To update the fork to use a new version of the upstream repository:
+
+1. If you haven't already, configure the upstream repository as a remote:
+
+   ```
+   git remote add upstream https://github.com/facebookincubator/create-react-app
+   ```
+
+1. [Sync the fork](https://help.github.com/articles/syncing-a-fork/)
+   to a branch, making sure you merge from a specific version/tag that
+   you want to base your changes on
+
+1. Make your changes, test them (see below), make a PR, release
+
+### Making changes and testing
+
+To test your local changes, link the local repository to the application:
+
+1. In the `create-react-app/packages/react-scripts` directory, install
+   dependencies and make a link of the package:
+
+   ```
+   yarn install # ignore the yarn.lock file
+   yarn link
+   ```
+
+1. In the application remove the old `sharetribe-scripts` package and
+   use the linked version:
+
+   ```
+   yarn remove sharetribe-scripts
+   yarn link sharetribe-scripts
+   ```
+
+1. Now you changes to the fork are usable as a symlicked dependency in
+   the application
+
+### Publishing
+
+1. Make sure you have updated the version also in the `description`
+   field in [package.json](package.json). Try to sync the package
+   version with the original package, if possible.
+
+1. Publish to NPM:
+
+   ```
+   npm publish
+   ```
+
+1. Tag the commit with released version: `sharetribe-scripts@x.x`

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "react-scripts",
+  "name": "sharetribe-scripts",
   "version": "1.0.14",
-  "description": "Configuration and scripts for Create React App.",
-  "repository": "facebookincubator/create-react-app",
+  "description": "Fork of facebookincubator/create-react-app@1.0.14 with some additional features.",
+  "repository": "sharetribe/create-react-app",
   "license": "MIT",
   "engines": {
     "node": ">=6"
@@ -18,7 +18,7 @@
     "utils"
   ],
   "bin": {
-    "react-scripts": "./bin/react-scripts.js"
+    "sharetribe-scripts": "./bin/react-scripts.js"
   },
   "dependencies": {
     "autoprefixer": "7.1.2",
@@ -55,7 +55,9 @@
     "webpack": "3.5.1",
     "webpack-dev-server": "2.8.2",
     "webpack-manifest-plugin": "1.2.1",
-    "whatwg-fetch": "2.0.3"
+    "whatwg-fetch": "2.0.3",
+    "postcss-cssnext": "3.0.2",
+    "postcss-import": "11.0.0"
   },
   "devDependencies": {
     "react": "^15.5.4",


### PR DESCRIPTION
Rebuild the configuration from the latest released version of `react-scripts`.

This new structure tries to be as minimal with the diff to the original project as possible to make it easy to update in the future.

Features compared to the previous version:

 - Drop custom ESLint config in favor of the builtin one
 - Start form a released version
 - Add new dependencies to the end of the dependency list in `package.json`
 - Change the Webpack config in a separate place to help with merge conflicts
 - Drop support for the `variables.js` file
 - Add documentation