### PR TITLE
Fix react-jsx error

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -148,7 +148,7 @@ function verifyTypeScriptSetup() {
     jsx: {
       parsedValue:
         hasJsxRuntime && semver.gte(ts.version, '4.1.0-beta')
-          ? ts.JsxEmit.ReactJsx
+          ? ts.JsxEmit.ReactJSX
           : ts.JsxEmit.React,
       value:
         hasJsxRuntime && semver.gte(ts.version, '4.1.0-beta')


### PR DESCRIPTION
At the moment TypeScript cannot be used in the FTW front-end.

See https://github.com/facebook/create-react-app/pull/9869

Alternatively you could pull in CRA 4.0.1 which also contains this fix.
