### PR TITLE
Override hosting instructions with FTW specific

### DIFF
--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -23,6 +23,7 @@ which version of `react-scripts` this fork is built from.
 - Use [postcss-import](https://github.com/postcss/postcss-import)
 - Use [postcss-apply](https://github.com/pascalduez/postcss-apply)
 - A separate `build-server` script that makes a build to use in SSR (server side rendering)
+- Show customized instructions how to run the production build bundle
 
 ## Development
 

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharetribe-scripts",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Fork of facebookincubator/create-react-app@4.0.0 with some additional features.",
   "repository": {
     "type": "git",

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -42,7 +42,7 @@ const checkRequiredFiles = require('react-dev-utils/checkRequiredFiles');
 const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
 
 //
-// Override the default hosting instructions with FTW specific instructions.
+// Sharetribe custom: override the default hosting instructions with FTW specific instructions.
 //
 // const printHostingInstructions = require('react-dev-utils/printHostingInstructions');
 //

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -40,7 +40,36 @@ const configFactory = require('../config/webpack.config');
 const paths = require('../config/paths');
 const checkRequiredFiles = require('react-dev-utils/checkRequiredFiles');
 const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
-const printHostingInstructions = require('react-dev-utils/printHostingInstructions');
+
+//
+// Override the default hosting instructions with FTW specific instructions.
+//
+// const printHostingInstructions = require('react-dev-utils/printHostingInstructions');
+//
+function printHostingInstructions(
+  appPackage,
+  publicUrl,
+  publicPath,
+  buildFolder,
+  useYarn
+) {
+  console.log();
+  console.log(`The ${chalk.cyan(buildFolder)} folder is ready to be deployed.`);
+  console.log();
+  console.log('You may serve it by running:');
+  console.log();
+  console.log(`  ${chalk.cyan('yarn')} start`);
+  console.log();
+  console.log('Find out more about deployment here:');
+  console.log();
+  console.log(
+    `  ${chalk.yellow(
+      'https://www.sharetribe.com/docs/ftw-hosting/how-to-deploy-ftw-to-production/'
+    )}`
+  );
+  console.log();
+}
+
 const FileSizeReporter = require('react-dev-utils/FileSizeReporter');
 const printBuildError = require('react-dev-utils/printBuildError');
 

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -56,11 +56,25 @@ function printHostingInstructions(
   console.log();
   console.log(`The ${chalk.cyan(buildFolder)} folder is ready to be deployed.`);
   console.log();
-  console.log('You may serve it by running:');
+  console.log(
+    'In local development machine you may serve it on production mode by running:'
+  );
+  console.log();
+  console.log(`  NODE_ENV=production PORT=3000 ${chalk.cyan('yarn')} start`);
+  console.log();
+  console.log(
+    'In production server (e.g. Heroku) we recommend you to set the environment'
+  );
+  console.log(
+    `variables ${chalk.cyan('NODE_ENV')} and ${chalk.cyan(
+      'PORT'
+    )} using provider\'s own mechanism to manage`
+  );
+  console.log('environment variables, and then start the app by running:');
   console.log();
   console.log(`  ${chalk.cyan('yarn')} start`);
   console.log();
-  console.log('Find out more about deployment here:');
+  console.log('Find out more about environment variables and deployment here:');
   console.log();
   console.log(
     `  ${chalk.yellow(


### PR DESCRIPTION
Hosting FTW with static server doesn't seem to work anymore. This is
probably due to code splitting.

Override the default instructions with FTW specific instructions.

I tested this with Verdaccion. Seems to work fine.

Before:

<img width="691" alt="Screen Shot 2021-08-03 at 14 46 59" src="https://user-images.githubusercontent.com/429876/128011907-d4309d15-b54e-4c7a-bc47-04776961b108.png">

After:

<img width="559" alt="Screen Shot 2021-08-03 at 15 59 49" src="https://user-images.githubusercontent.com/429876/128019684-145b1d90-a584-40d3-9ec1-2fd3412858db.png">

