### PR TITLE
Fix GENERATE_SOURCEMAP and revert splitChunk

### DIFF
--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -60,6 +60,35 @@ To update the fork to use a new version of the upstream repository:
 
 To test your local changes, use [Verdaccio](https://verdaccio.org/en/) or link the local repository to the application:
 
+#### Verdaccio
+
+1. Run Verdaccio locally (http://localhost:4873/) and create user there
+
+1. Make changes to this repo and update version in the package.json of this react-scripts dir
+   The version could be something like "6.0.0-alpha"
+
+1. Publish your changes to the local registry
+
+   ```
+   npm publish --registry http://localhost:4873/
+   ```
+
+1. Go to FTW repo and add .yarnrc file with content:
+
+   ```
+   registry "http://localhost:4873"
+   ```
+
+1. Modify FTW template's package.json
+
+   ```
+   "sharetribe-scripts": "6.0.0-alpha",
+   ```
+
+   Then run `yarn install`
+
+#### Linking
+
 1. In the `create-react-app/packages/react-scripts` directory, install
    dependencies and make a link of the package:
 

--- a/packages/react-scripts/config/sharetribeWebpackConfig.js
+++ b/packages/react-scripts/config/sharetribeWebpackConfig.js
@@ -45,25 +45,21 @@ const postcssOptionsPlugins = [
 const checkConfigStructure = config => {
   // First validate the structure of the config to ensure that we mutate
   // the config with the correct assumptions.
-  const hasRules =
-    config &&
-    config.module &&
-    config.module.rules &&
-    config.module.rules.length === 2;
-  const hasOneOf =
+  const hasRules = config?.module?.rules?.length > 0;
+  const foundRuleWithOneOfArray =
     hasRules &&
-    config.module.rules[1].oneOf &&
-    config.module.rules[1].oneOf.length === 10;
+    config.module.rules.find(rule => rule.oneOf?.length === 10);
+
   const hasCssLoader =
-    hasOneOf &&
-    config.module.rules[1].oneOf[5].test &&
-    config.module.rules[1].oneOf[5].test.test('file.css');
+    foundRuleWithOneOfArray &&
+    foundRuleWithOneOfArray.oneOf[5].test &&
+    foundRuleWithOneOfArray.oneOf[5].test.test('file.css');
   const hasPlugins = !!config.plugins;
   const hasOutput = !!config.output;
   const hasOptimization = !!config.optimization;
 
   const configStructureKnown = hasRules
-        && hasOneOf
+        && foundRuleWithOneOfArray
         && hasCssLoader
         && hasPlugins
         && hasOutput

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -252,14 +252,6 @@ module.exports = function(webpackEnv, target = 'web') {
       level: 'none',
     },
     optimization: {
-      // Sharetribe custom: create vendor chunk
-      // CRA v5, removed this splitChunks feature, but they are planning to reintroduce it.
-      // https://github.com/facebook/create-react-app/pull/11763
-      splitChunks: isEnvDevelopment
-      ? undefined
-      : {
-          chunks: 'all',
-        },
       minimize: isEnvProduction,
       minimizer: [
         // This is only used in production mode

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharetribe-scripts",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Fork of facebookincubator/create-react-app@5.0.1 with some additional features. This is a major version update to CRA",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently released as 6.0.1-RC

## 2 fixes:
### Remove vendor code chunk
splitChunks was reintroduced prematurely.
CRA 5 is discussing reintroducing it, but the previous (CRA4) style does not work with 'async' marked thunk functions.

I.e. this was removed:
```
      // Sharetribe custom: create vendor chunk
      // CRA v5, removed this splitChunks feature, but they are planning to reintroduce it.
      // https://github.com/facebook/create-react-app/pull/11763
      splitChunks: isEnvDevelopment
        ? undefined
        : {
            chunks: 'all',
          },      
```

### Error when using env variable: GENERATE_SOURCEMAP=false
GENERATE_SOURCEMAP=false caused an error since it modified the structure of webpack.config.js

