### PR TITLE
@loadable/babel-plugin: should be applied to both builds

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -454,7 +454,7 @@ module.exports = function(webpackEnv, target = 'web') {
 
                   // Sharetribe custom: add loadable babel plugin for
                   // application files
-                  isTargetNode && require.resolve('@loadable/babel-plugin'),
+                  require.resolve('@loadable/babel-plugin'),
 
                   isEnvDevelopment &&
                     shouldUseReactRefresh &&

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharetribe-scripts",
-  "version": "6.0.2",
+  "version": "7.0.0",
   "description": "Fork of facebookincubator/create-react-app@5.0.1 with some additional features. This is a major version update to CRA",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This breaks the UI on sharetribe/web-template, we need to make major release
